### PR TITLE
:pencil: Edit background, margins, correct links

### DIFF
--- a/_pages/landing-page.html
+++ b/_pages/landing-page.html
@@ -101,6 +101,10 @@ title: DjangoCon US 2019 conference will take place in TBD from September 15-20,
       color: white;
     }
 
+    .mailingList {
+      margin-top: 2em;
+    }
+
     .button:hover {
       background: var(--color-secondary);
     }
@@ -294,6 +298,9 @@ title: DjangoCon US 2019 conference will take place in TBD from September 15-20,
       <svg class="logo"><title>DjangoCon.US</title><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#logo"></use></svg>
       <h1 class="conf-locdate">TBD <!-- San Diego, CA --> &ndash; Sep 15-20, 2019</h1>
       <h2 class="conf-description">Join us for six days of inspiration, education, and networking opportunities.</h2>
+      <a
+            href="https://djangocon.us11.list-manage.com/subscribe?u=9ae17a6371d9ee8412eb23910&id=b106911995"
+            class="button mailingList">Join our mailing list</a>
     </header>
     <main class="siteMain">
       <div class="featuresBlock">

--- a/_pages/landing-page.html
+++ b/_pages/landing-page.html
@@ -23,7 +23,7 @@ title: DjangoCon US 2019 conference will take place in TBD from September 15-20,
       --color-primary   : #6D0F84;
       --color-secondary : #EA5397;
       --color-highlight : #FC7E56;
-      --color-background: #E9E9E9;
+      --color-background: #FFF;
       --color-logo      : #B52BC9;
       --color-font      : #1E1E1E;
 
@@ -112,7 +112,7 @@ title: DjangoCon US 2019 conference will take place in TBD from September 15-20,
 
     .siteHeader {
       padding: 2rem 2rem 4rem;
-      background: #F1FFFA;
+      background: #FFF;
       text-align: center;
     }
 
@@ -185,6 +185,7 @@ title: DjangoCon US 2019 conference will take place in TBD from September 15-20,
       line-height: 1.3;
       text-align: center;
       color: white;
+      margin-top: 3rem;
     }
 
     .spBlock p {
@@ -303,7 +304,7 @@ title: DjangoCon US 2019 conference will take place in TBD from September 15-20,
             class="feature-icon">
           <h3>Learn from Django's Brightest</h3>
           <p>Every conference is packed with talks and workshops by Django veterans and enthusiastic first-time presenters.</p>
-          <a href="https://2017.djangocon.us/schedule/" class="cta">See last year's schedule</a>
+          <a href="https://2018.djangocon.us/schedule/" class="cta">See last year's schedule</a>
         </section>
         <section class="feature">
           <img
@@ -323,9 +324,10 @@ title: DjangoCon US 2019 conference will take place in TBD from September 15-20,
           <h3>Code of Conduct</h3>
           <p>Participants are expected to be respectful to each other. DjangoCon US is a welcoming environment.</p>
 
-          <a href="https://github.com/djangocon/2019.djangocon.us/blob/master/coc.md" class="cta">See our code of conduct</a>
+          <a href="https://github.com/djangocon/2019.djangocon.us/blob/master/CODE_OF_CONDUCT.md" class="cta">See our code of conduct</a>
         </section>
       </div>
+
       <section class="spBlock">
         <h2 class="spBlock-title">Sponsor DjangoCon US</h2>
         <p>By giving to the community who builds and supports the software you use, you help ensure its happiness, health, and productivity. Sponsoring DjangoCon US also puts your brand in front of &gt;10,000 Python professionals and opportunities to speak directly to all of them.</p>
@@ -334,9 +336,10 @@ title: DjangoCon US 2019 conference will take place in TBD from September 15-20,
           <a
             href="mailto:hello@djangocon.us?subject=Sponsorsing DjangoCon US 2019"
             class="button">Ask About Sponsorship</a>
+            <!--
             <a
             href="https://drive.google.com/file/d/12nkZ93LjEqVMwk-PZ9Ka_uQa99_1ZOYu/view"
-            class="button">See Our Prospectus</a>
+            class="button">See Our Prospectus</a>-->
         </p>
       </section>
     </main>


### PR DESCRIPTION
- Correct CoC link 
- Comments out link to 2018 Sponsor prospectus 
- Corrects link to "last year's" schedule 
- Makes all background white (personal opinion: looks cleaner) 
- Adds a little padding on top of the sponsors section 
- Adds link to mailing list 


![screen shot 2018-10-22 at 11 29 16 am](https://user-images.githubusercontent.com/2286304/47311261-18cfbb80-d5ee-11e8-9ffa-715a9fdd84d3.png)

