### PR TITLE
Update Why DjangoCon US

### DIFF
--- a/_pages/why-djangocon-us.html
+++ b/_pages/why-djangocon-us.html
@@ -143,11 +143,11 @@ description: |
       <section class="video-card">
         <span class="label box">Last Year's Top Session</span>
         <div class="responsive-embed widescreen">
-          <iframe width="640" height="385" src="https://www.youtube.com/embed/BRCx6lSA0fM" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
-          <!-- <iframe width="560" height="315" src="https://www.youtube.com/embed/pY-oje5b5Qk" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe> -->
+          <!-- LAST YEAR: <iframe width="640" height="385" src="https://www.youtube.com/embed/BRCx6lSA0fM" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe> -->
+          <iframe width="560" height="315" src="https://www.youtube.com/embed/pY-oje5b5Qk" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
         </div>
         <h3 class="video-card-title">Finally Understand Authentication in Django REST Framework</h3>
-        <h4 class="video-card-presenter">by Ganesh Swami</h4>
+        <h4 class="video-card-presenter">by William S. Vincent</h4>
       </section>
     </div>
   </div>

--- a/_pages/why-djangocon-us.html
+++ b/_pages/why-djangocon-us.html
@@ -143,7 +143,6 @@ description: |
       <section class="video-card">
         <span class="label box">Last Year's Top Session</span>
         <div class="responsive-embed widescreen">
-          <!-- LAST YEAR: <iframe width="640" height="385" src="https://www.youtube.com/embed/BRCx6lSA0fM" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe> -->
           <iframe width="560" height="315" src="https://www.youtube.com/embed/pY-oje5b5Qk" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
         </div>
         <h3 class="video-card-title">Finally Understand Authentication in Django REST Framework</h3>

--- a/_pages/why-djangocon-us.html
+++ b/_pages/why-djangocon-us.html
@@ -144,8 +144,9 @@ description: |
         <span class="label box">Last Year's Top Session</span>
         <div class="responsive-embed widescreen">
           <iframe width="640" height="385" src="https://www.youtube.com/embed/BRCx6lSA0fM" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
+          <!-- <iframe width="560" height="315" src="https://www.youtube.com/embed/pY-oje5b5Qk" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe> -->
         </div>
-        <h3 class="video-card-title">Butter smooth, interactive applications with Django and Websockets</h3>
+        <h3 class="video-card-title">Finally Understand Authentication in Django REST Framework</h3>
         <h4 class="video-card-presenter">by Ganesh Swami</h4>
       </section>
     </div>
@@ -159,24 +160,24 @@ description: |
     data-equalizer data-equalize-on="medium">
     <div class="column column-block">
       <section class="event boxed" data-equalizer-watch>
-        <a href="https://2017.djangocon.us/talks/using-django-docker-and-scikit-learn-to-bootstrap-your-machine-learning-project/" class="event-content">
-          <h3 class="event-title">Using Django, Docker, and Scikit-learn to Bootstrap Your Machine Learning Project</h3>
+        <a href="https://2018.djangocon.us/talk/orm-the-sequel/" class="event-content">
+          <h3 class="event-title">ORM: The Sequel</h3>
           <span class="label" aria-label="Session type:">Talk</span>
           <span class="label" aria-label="Audience level:">Intermediate</span>
           <p class="event-byline">
-            By Lorena Mesa
+            By Katie McLaughlin
           </p>
         </a>
       </section>
     </div>
     <div class="column column-block">
       <section class="event boxed" data-equalizer-watch>
-        <a href="https://2017.djangocon.us/tutorials/from-0-to-100-in-django/" class="event-content">
-          <h3 class="event-title">From 0 to 100 in Django</h3>
-          <span class="label" aria-label="Session type:">Tutorial</span>
-          <span class="label" aria-label="Audience level:">Beginner</span>
+        <a href="https://2018.djangocon.us/talk/auto-generating-an-api-using-postgresql/" class="event-content">
+          <h3 class="event-title">Auto-generating an API using PostgreSQL, Django, and Django REST Framework</h3>
+          <span class="label" aria-label="Session type:">Talk</span>
+          <span class="label" aria-label="Audience level:">Intermediate</span>
           <p class="event-byline">
-            By Jeremy Spencer
+            By Mjumbe Poe
           </p>
         </a>
       </section>
@@ -191,37 +192,36 @@ description: |
     </div>
     <div class="column column-block">
       <section class="event boxed" data-equalizer-watch>
-        <a href="https://2017.djangocon.us/tutorials/build-a-graphql-api-using-django/" class="event-content">
-          <h3 class="event-title">Build a GraphQL API Using
-Django</h3>
-          <span class="label" aria-label="Session type:">Tutorial</span>
-          <span class="label" aria-label="Audience level:">Intermediate</span>
-          <p class="event-byline">
-            By Murange James
-          </p>
-        </a>
-      </section>
-    </div>
-    <div class="column column-block">
-      <section class="event boxed" data-equalizer-watch>
-        <a href="https://2017.djangocon.us/talks/write-an-api-for-almost-anything-or-the-amazing-power-and-flexibility-of-django-rest-framework/" class="event-content">
-          <h3 class="event-title">Write an API for Almost Anything (or The Amazing Power and Flexibility of Django Rest Framework</h3>
-          <span class="label" aria-label="Session type:">Talk</span>
-          <span class="label" aria-label="Audience level:">All Levels</span>
-          <p class="event-byline">
-            By Charlotte Mays
-          </p>
-        </a>
-      </section>
-    </div>
-    <div class="column column-block">
-      <section class="event boxed" data-equalizer-watch>
-        <a href="https://2017.djangocon.us/talks/files-in-django/" class="event-content">
-          <h3 class="event-title">Files in Django</h3>
+        <a href="https://2018.djangocon.us/talk/an-intro-to-docker-for-djangonauts/" class="event-content">
+          <h3 class="event-title">An Intro to Docker for Djangonauts</h3>
           <span class="label" aria-label="Session type:">Talk</span>
           <span class="label" aria-label="Audience level:">Beginner</span>
           <p class="event-byline">
-            By Josh Schneier
+            By Lacey Williams Henschel
+          </p>
+        </a>
+      </section>
+    </div>
+    <div class="column column-block">
+      <section class="event boxed" data-equalizer-watch>
+        <a href="https://2018.djangocon.us/tutorial/api-driven-django/" class="event-content">
+          <h3 class="event-title">API-Driven Django</h3>
+          <span class="label" aria-label="Session type:">Tutorial</span>
+          <span class="label" aria-label="Audience level:">Intermediate</span>
+          <p class="event-byline">
+            By Philip James
+          </p>
+        </a>
+      </section>
+    </div>
+    <div class="column column-block">
+      <section class="event boxed" data-equalizer-watch>
+        <a href="https://2018.djangocon.us/tutorial/what-to-expect-when-you-re-expecting-a/" class="event-content">
+          <h3 class="event-title">What To Expect When You're Expecting: A Hands-On Guide to Regression Testing</h3>
+          <span class="label" aria-label="Session type:">Tutorial</span>
+          <span class="label" aria-label="Audience level:">Intermediate</span>
+          <p class="event-byline">
+            By Emily Morehouse-Valcarcel
           </p>
         </a>
       </section>


### PR DESCRIPTION
**NEEDED: code review specifically on line #147.**

Replaced the talks/tutorials from 2017 with talks/tutorials from 2018. 

Added a replacement for the "Last Year's Top Session" video, but the direct copy of the embed code from youtube looks different from what we had last year, so I just want to make sure I shouldn't update the attributes to be exactly what they were in 2018 before I delete the iframe from 2018 (currently commented out). 

Please comment what changes I should make on line 146/147 (if necessary) and I'll update it appropriately.

Closes a few of the boxes in #18 

Changes proposed in this PR:

- replace 2017 examples with 2018 examples on the "Why DjangoCon US" page
