### PR TITLE
:pencil: Comment out 2018 schedule stuff

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -45,13 +45,13 @@ layout: base
     <p class="lead column large-9 large-centered text-center">Join us for a source of inspiration, education and networking opportunities. Our team is making sure that participating in DjangoCon US is easy for you!</p>
 
     <div class="date-card medium-4 column">
-      <a href="/tutorials"><div class="row collapse">
+      <div class="row collapse">
         <div class="small-5 column">
           <div class="dates">
             <div class="month">Sept</div>
             <div class="days">22</div>
           </div>
-        </div></a>
+        </div>
         <div class="small-7 column">
           <h2 class="date-card-title">Tutorials</h2>
           <p>One day, numerous tutorials</p>
@@ -59,13 +59,13 @@ layout: base
       </div>
     </div>
     <div class="date-card medium-4 column">
-      <a href="/talks"><div class="row collapse">
+      <div class="row collapse">
         <div class="small-5 column">
           <div class="dates">
             <div class="month">Sept</div>
             <div class="days">23-25</div>
           </div>
-        </div></a>
+        </div>
         <div class="small-7 column">
           <h2 class="date-card-title">Talks</h2>
           <p>Dozens of talks chosen by the community</p>
@@ -73,13 +73,13 @@ layout: base
       </div>
     </div>
     <div class="date-card medium-4 column">
-      <a href="/sprints"><div class="row collapse">
+      <div class="row collapse">
         <div class="small-5 column">
           <div class="dates">
             <div class="month">Sept</div>
             <div class="days">26-27</div>
           </div>
-        </div></a>
+        </div>
         <div class="small-7 column">
           <h2 class="date-card-title">Sprints</h2>
           <p>Team up to work on Django!</p>

--- a/_pages/schedule.html
+++ b/_pages/schedule.html
@@ -7,6 +7,9 @@ heading: Full Conference Schedule
 sitemap: false
 ---
 
+Coming soon!
+
+{% comment %}
 <nav class="schedule-nav">
   <span
     class="schedule-nav-title">Jump to:</span>
@@ -141,3 +144,4 @@ sitemap: false
   </div>
 </section>
 <!-- sprints: day 2 -->
+{% endcomment %}


### PR DESCRIPTION
Changes proposed in this PR:

- Removes links to schedule page from homepage calendar icons
- Comments out the schedule on the schedule pages 
- Leaves the schedule files from last year so the script to update them to this year's talks can run more easily. 

![Screen Shot 2019-06-05 at 9 39 28 AM](https://user-images.githubusercontent.com/2286304/58973907-f56d1180-8775-11e9-9e5f-c290548227be.png)

