### PR TITLE
Removed link to 2018 spreadsheet for Lightning Talks

### DIFF
--- a/_schedule/talks/2019-09-24-12-50-t0-lightning-talks.md
+++ b/_schedule/talks/2019-09-24-12-50-t0-lightning-talks.md
@@ -16,6 +16,4 @@ track: t0
 
 Salon A-E
 
-Signup link is: [http://bit.ly/dcus2018lt](http://bit.ly/dcus2018lt)
-
 Tuesday sign ups go live Monday at 2:20pm and close Tuesday at 9am (please eat breakfast!) with speaker notifications by 11am Tuesday.

--- a/_schedule/talks/2019-09-25-12-50-t0-lightning-talks.md
+++ b/_schedule/talks/2019-09-25-12-50-t0-lightning-talks.md
@@ -16,6 +16,4 @@ track: t0
 
 Salon A-E
 
-Signup link is: [http://bit.ly/dcus2018lt](http://bit.ly/dcus2018lt)
-
 Wednesday sign ups go live Tuesday at 2:20pm and close Wednesday at 9am (please eat breakfast!) with speaker notifications by 11am Wednesday.


### PR DESCRIPTION
Changes proposed in this PR:

- Remove link to last year's spreadsheet for the two days of talks
