### PR TITLE
:pencil: Replace sponsors link with volunteer link on home page

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -108,8 +108,8 @@ layout: base
           class="card-icon"
           />
         <div class="card-section">
-          <h3 class="card-title">Sponsors!</h3>
-          <p>We can't put on DjangoCon US without you. Go ahead and <strong><a href="mailto:{{site.sponsors_email}}">drop us a line</a></strong> so we can talk to you about how we can make it easy for you to sponsor us.</p>
+          <h3 class="card-title">Volunteer</h3>
+          <p>We can't put on DjangoCon US without you. <a href="https://docs.google.com/spreadsheets/d/1VO8Xh6xPOQb32WjUD7pKJCMXvqCdcMz95CqIoNToUsA/edit#gid=0">Sign up to volunteer</a> at the registration desk, as a session chair, or as a sprints mentor!</p>
         </div>
       </div>
     </div>

--- a/_pages/sponsors-information.md
+++ b/_pages/sponsors-information.md
@@ -18,11 +18,12 @@ Sponsoring DjangoCon US can help you:
 
 Because the conference is organized by [DEFNA](https://www.defna.org/), a non-profit 501(c)(3) organization, your sponsorship is tax-deductible!
 
-{% comment %}
-**Sponsorship is closed for this year**. Want to know more about sponsorship for 2019?
-{% endcomment %}
+**Sponsorship is closed for this year**. Want to know more about sponsorship for 2020?
 
-Want to know more about sponsorship? 
+
+{% comment %}
+Want to know more about sponsorship?
+{% endcomment %}
 
 <a href="mailto:{{site.sponsors_email}}" class="button">Contact Us Today</a>
 
@@ -78,11 +79,7 @@ Interested in another sponsorship opportunity? Get in touch and we’ll do our b
 
 ## Interested in Sponsoring?
 
-{% comment %}
-Sponsorship is closed for this year. But we're recruiting for DjangoCon US 2019! <strong><a href="mailto:{{site.sponsors_email}}
-{% endcomment %}
-
-<strong><a href="mailto:{{site.sponsors_email}}">Send us an email!</a></strong> We're here to help make the process of becoming a sponsor as easy as we can!
+Sponsorship is closed for this year. But we're recruiting for DjangoCon US 2020! <strong><a href="mailto:{{site.sponsors_email}}">Send us an email!</a></strong> We're here to help make the process of becoming a sponsor as easy as we can!
 
 {% comment %}
 #### Booth info


### PR DESCRIPTION
Changes proposed in this PR:

- Removes link to contact us about sponsoring from homepage, since sponsor signups are closed. 
- Adds link to volunteer spreadsheet to homepage. 
- Updates sponsor info page to reflect that sponsorship is closed for this year. 
