### PR TITLE
Update game location

### DIFF
--- a/_layouts/session-details.html
+++ b/_layouts/session-details.html
@@ -66,6 +66,8 @@ layout: base
     </div>
   </div><!-- end .row -->
 
+{% if page.presenters %}
+
 <div class="presenters section-pad theme-light-gray">
   <div class="row">
     <div class="column medium-10 medium-offset-1"><h2>Presenters</h2></div>
@@ -125,6 +127,8 @@ layout: base
     </div>
   {% endfor %}
 </div>
+
+{% endif %}
 
 
 </div><!-- end .content -->

--- a/_schedule/talks/2019-09-24-18-00-board-game-night.md
+++ b/_schedule/talks/2019-09-24-18-00-board-game-night.md
@@ -8,8 +8,7 @@ difficulty: null
 end_date: 2019-09-24 22:00:00 -0500
 layout: session-details
 permalink: /social-event/board-game-night/
-presenters: []
-room: Salon E
+room: Rio Vista Ballroom Salons A-E
 sitemap: true
 talk_slot: full
 title: Board Game Night


### PR DESCRIPTION
Closes # .

Changes proposed in this PR:

- Hides presenters in session details if no presenters 
- Updates board game night location per comment in https://trello.com/c/deO4NnQB 
