### PR TITLE
Add jobs board link

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -3,6 +3,7 @@
   <ul class="menu vertical nested">
     <li><a href="/about/">About DjangoCon US</a></li>
     <li><a href="/tickets/">Tickets</a></li>
+    <li><a href="/job-board/">Jobs Board</a></li>
     <li><a href="/faq/">FAQ</a></li>
     <li><a href="/conduct/">Code of Conduct</a></li>
     <li><a href="/opportunity-grants/">Opportunity Grants</a></li>

--- a/_pages/faqs.html
+++ b/_pages/faqs.html
@@ -43,10 +43,7 @@ sitemap: false
     <div class="row column faq-list">
       <section class="faq-item">
         <h2 class="text-center">Schedule</h2>
-        <p><em>A detailed schedule is forthcoming.</em></p>
-        {% comment %}
         <p><em>More information can be found on the <a href="/schedule">Schedule</a> page.</em></p>
-        {% endcomment %}
         <ul>
           <li>Will after-hours events, like the opening reception{% comment %} or a board game night{% endcomment %}, be listed on the schedule?</li>
           <li>Will videos of talks be posted online?</li>
@@ -83,7 +80,8 @@ sitemap: false
           <li>Is step-free access available to all parts of the venue, including presentation areas?</li>
           <li>Is there a nearby recovery meeting?</li>
           <li>Will there be vegetarian, vegan, and/or gluten-free options at meals?</li>
-          <li>Will you reimburse me for some of my childcare expenses{% comment %}<a href="/news/childcare-update/">childcare expenses</a>{% endcomment %}?</li>
+          <li>Will you reimburse me for some of my <a href="/news/childcare-during-djangocon/">childcare expenses</a>?</li>
+          <li>Is there a <a href="/news/lactation-room/">lactation room</a>?</li>
         </ul>
       </section>
     </div>
@@ -106,10 +104,11 @@ sitemap: false
     <div class="row column faq-list">
       <section class="faq-item">
         <h2 class="text-center">Sponsors</h2>
-        <p><em>More information is on our <a href="{% link _pages/sponsors-information.md %}">Become a Sponsor</a> page. {% comment %}Sponsorship signups for 2019 are now closed.{% endcomment %}</em></p>
+        <p><em>More information is on our <a href="{% link _pages/sponsors-information.md %}">Become a Sponsor</a> page. Sponsorship signups for 2019 are now closed.</em></p>
         <ul>
-          <li>Can I sign up as a sponsor for DjangoCon US 2019?</li>
+          <li>Can I sign up as a sponsor for DjangoCon US 2020?</li>
           <li>Can I sign up as a sponsor for <a href="{% link _pages/opportunity-grants.md %}#how-to-donate">Opportunity Grants</a>?</li>
+          <li>Are any of the sponsors <a href="/job-board/">hiring</a>?</li>
         </ul>
       </section>
     </div>

--- a/_pages/sponsors.html
+++ b/_pages/sponsors.html
@@ -18,12 +18,9 @@ description: DjangoCon US is only possible through the support of various organi
     </div>
     <div class="medium-5 large-4 column">
       <div class="callout text-center partner-cta-box">
-        <h2>Sponsor DjangoCon US</h2>
-        <p>By supporting the community who builds and supports the software you use, you help ensure its happiness, health, and productivity.</p>
-        {% comment %}
-        <p>Sponsorship for 2019 is now closed. But you can support the community who builds and supports the software you use by signing up as a 2019 conference sponsor!</p>
-        {% endcomment %}
-        <a href="/sponsors/information/" class="button">Become a Sponsor for 2019</a>
+        <h2>Looking for a job?</h2>
+        <p>Some of our sponsors are hiring! Take a look at our virtual jobs board to learn more.</p>
+        <a href="/job-board/" class="button">Check out our jobs board</a>
       </div>
     </div>
   </div>
@@ -48,6 +45,7 @@ description: DjangoCon US is only possible through the support of various organi
               <h3 class="partner-name"><a href="{{ sponsor.url_target }}" rel="sponsored">{{ sponsor.name }}</a></h3>
               {% capture sponsor_description %}{{ sponsor.description }}{: .partner-description }{% endcapture %}
               {{ sponsor_description | markdownify }}
+              {% if sponsor.hiring %}<a href="/job-board/" class="button">{{ sponsor.name }} is hiring!</a>{% endif %}
             </div>
           </div>
         {% endunless %}

--- a/_sponsors/2018-06-28-defna.md
+++ b/_sponsors/2018-06-28-defna.md
@@ -10,4 +10,5 @@ url_target: "https://www.defna.org/"
 url_friendly: "defna.org"
 description: |
       Django Events Foundation North America (DEFNA) is a non-profit based in California USA. It was formed in 2015 at the request of the Django Software Foundation (DSF) to run DjangoCon US. The DSF have licensed DEFNA to run DjangoCon US since 2015. Beyond DjangoCon US we also plan to be involved with other events in North America that cover the education and outreach of Django.
+hiring: false
 ---

--- a/_sponsors/2018-06-29-dsf.md
+++ b/_sponsors/2018-06-29-dsf.md
@@ -10,4 +10,5 @@ url_target: "https://www.djangoproject.com/foundation/"
 url_friendly: "djangoproject.com/foundation"
 description: |
   Development of Django is supported by an independent foundation established as a 501(c)(3) non-profit. Like most open-source foundations, the goal of the Django Software Foundation is to promote, support, and advance its open-source project: in our case, the Django Web framework.
+hiring: false
 ---

--- a/_sponsors/2018-06-30-psf.md
+++ b/_sponsors/2018-06-30-psf.md
@@ -10,4 +10,5 @@ url_target: "https://www.python.org/psf/"
 url_friendly: "python.org/psf"
 description: |
   The Python Software Foundation (PSF) is a 501(c)(3) non-profit corporation that holds the intellectual property rights behind the Python programming language. We manage the open source licensing for Python version 2.1 and later and own and protect the trademarks associated with Python. We also run the North American PyCon conference annually, support other Python conferences around the world, and fund Python related development with our grants program and by funding special projects.
+hiring: false
 ---

--- a/_sponsors/2018-07-21-jbssolutions.md
+++ b/_sponsors/2018-07-21-jbssolutions.md
@@ -16,4 +16,5 @@ description: |
   They work primarily in Django, but other technologies occasionally
   fit applications better (even Microsoft - a separate team is a
   Gold Application Development partner.)
+hiring: false
 ---

--- a/_sponsors/2018-08-11-caktus-group.md
+++ b/_sponsors/2018-08-11-caktus-group.md
@@ -19,4 +19,5 @@ description: |
   clients include Mozilla, UChicago, PBS, Discovery Communications
   and others in media, travel, education, finance, and health
   research.
+hiring: false
 ---

--- a/_sponsors/2018-08-11-oreilly.md
+++ b/_sponsors/2018-08-11-oreilly.md
@@ -13,4 +13,5 @@ description: |
   O’Reilly is a learning company that helps individuals, teams, and enterprises build skills to succeed in a world defined by technology-driven transformation.
 
   From in-person conferences and live online training courses to self-directed learning and immediate access to problem solving online, O’Reilly has you and your team covered.
+hiring: false
 ---

--- a/_sponsors/2019-03-05-sixfeetup.md
+++ b/_sponsors/2019-03-05-sixfeetup.md
@@ -16,4 +16,5 @@ description: |
   We offer assistance with AWS deployments and Cloud
   performance optimization. We believe in automation
   and orchestration.
+hiring: false
 ---

--- a/_sponsors/2019-03-10-guidebook.md
+++ b/_sponsors/2019-03-10-guidebook.md
@@ -14,4 +14,5 @@ description: |
   skills required. Just choose from a gallery of mobile app
   templates, select your features, and fill it with content.
   Then publish in minutes to Google Play and the Apple App Store.
+hiring: false
 ---

--- a/_sponsors/2019-03-18-lincoln-loop.md
+++ b/_sponsors/2019-03-18-lincoln-loop.md
@@ -10,4 +10,5 @@ url_target: "https://lincolnloop.com/"
 url_friendly: "lincolnloop.com"
 description: |
   Lincoln Loop is a full-service software development agency specializing in Python and Django development for web and mobile. Since 2007 our emphasis on quality in an agile environment has helped numerous startups and high-traffic sites grow their businesses. In addition to rock solid Python powered backends, Lincoln Loop provides user experience, deployment, and real-time application development with JavaScript.
+hiring: false
 ---

--- a/_sponsors/2019-03-19-revsys.md
+++ b/_sponsors/2019-03-19-revsys.md
@@ -10,4 +10,5 @@ url_target: "http://www.revsys.com/"
 url_friendly: "revsys.com"
 description: |
   We are performance tuners, Python and Django experts, infrastructure and scaling architects. Your best opportunity for success in any situation is to have access to the highest level of knowledge and a thorough understanding of how to make the most of it. What you don't know can hurt you. Let us help you over and around the bumps in the road you are on. At REVSYS, we help our clients with architecture decisions, implementing best practices, identifying cost savings, improving development velocity, mentoring, and ops automation. You need to move fast. We can help rev up your people, processes, and products.
+hiring: false
 ---

--- a/_sponsors/2019-03-20-nexmo.md
+++ b/_sponsors/2019-03-20-nexmo.md
@@ -10,4 +10,5 @@ url_target: "https://www.nexmo.com/"
 url_friendly: "www.nexmo.com"
 description: |
   Nexmo is a global communications platform, providing APIs and SDKs for SMS, voice, phone verification, messaging and advanced multi-channel conversations. We have officially supported open source libraries for Python, Node.JS, Ruby, PHP, Java and C# .NET enabling you to build scalable communications features such as two-factor authentication, two-way and group messaging and one to one or multi person calls.
+hiring: false
 ---

--- a/_sponsors/2019-03-22-doctor-on-demand.md
+++ b/_sponsors/2019-03-22-doctor-on-demand.md
@@ -10,4 +10,5 @@ url_target: "https://www.doctorondemand.com/"
 url_friendly: "doctorondemand.com"
 description: |
   Doctor On Demand is the fastest, easiest way to see a board-certified doctor or psychologist on your computer, tablet, or phone - from the comfort of home. Our doctors see and treat hundreds of medical issues and our therapists provide a safe, confidential space for you to get the treatment you need to help with your life.
+hiring: false
 ---

--- a/_sponsors/2019-06-17-netlandish.md
+++ b/_sponsors/2019-06-17-netlandish.md
@@ -19,4 +19,5 @@ description: |
   understand the business impacts. Don’t listen to us
   though… Just ask for references. Our customers will
   sell our services way better than we ever could.
+hiring: false
 ---

--- a/_sponsors/2019-06-18-PGX.md
+++ b/_sponsors/2019-06-18-PGX.md
@@ -18,4 +18,5 @@ description: |
   PostgreSQL committers and contributors, and contributors to
   database-backed applications in Django, Perl, PHP, Python
   and Java.
+hiring: false
 ---

--- a/_sponsors/2019-06-18-fusionbox.md
+++ b/_sponsors/2019-06-18-fusionbox.md
@@ -10,4 +10,5 @@ url_target: "https://www.fusionbox.com/"
 url_friendly: "www.fusionbox.com"
 description: |
   Fusionbox is a custom software development agency specializing in Python/Django, ETL, and application security. They’ve helped companies big and small develop software since 2002.
+hiring: false
 ---

--- a/_sponsors/2019-06-18-sixfeetupbronze.md
+++ b/_sponsors/2019-06-18-sixfeetupbronze.md
@@ -15,4 +15,5 @@ description: |
   using Django, Pyramid and Plone. We offer assistance with
   AWS deployments and Cloud performance optimization. We
   believe in automation and orchestration.
+hiring: false
 ---

--- a/_sponsors/2019-06-18-vinta.md
+++ b/_sponsors/2019-06-18-vinta.md
@@ -16,4 +16,5 @@ description: |
   their platform from scratch or to consult on an existing team. We
   are also keen on community contribution, talking at conferences
   all around the world about Python and JS.
+hiring: false
 ---

--- a/_sponsors/2019-07-01-labcodes.md
+++ b/_sponsors/2019-07-01-labcodes.md
@@ -11,4 +11,5 @@ url_friendly: "www.labcodes.com.br"
 description: |
   Labcodes is a software studio based in Brazil that designs, implements, and scales digital products. We deliver great experiences and build web applications that fit customers’ needs using Python, Django, and React. Our projects are centered in creating unique solutions that brings value to its users, and therefore to our clients.
   We’ve been partnering with US clients for almost 5 years helping a big variety of companies, from 1-person startups and YC startups to well established companies. Our team is talented and recognized worldwide, giving talks and mentoring people.
+hiring: false
 ---

--- a/_sponsors/2019-08-09-tito.md
+++ b/_sponsors/2019-08-09-tito.md
@@ -10,4 +10,5 @@ url_target: "https://ti.to/home"
 url_friendly: "ti.to/home"
 description: |
   Tito is designed to provide a stress-free experience for organisers and attendees. We sweat the software details so that you can focus on planning a great event.
+hiring: false
 ---

--- a/_sponsors/2019-08-09-whitesource.md
+++ b/_sponsors/2019-08-09-whitesource.md
@@ -16,4 +16,5 @@ description: |
   components in your repository, build tools and CI servers to alert in real-time on
   vulnerable and problematic components, enforces policies automatically, provides
   remediation suggestions and generates comprehensive reports in one click.
+hiring: false
 ---

--- a/_sponsors/2019-08-11-23andme.md
+++ b/_sponsors/2019-08-11-23andme.md
@@ -10,4 +10,5 @@ url_target: "https://www.23andme.com"
 url_friendly: "www.23andme.com"
 description: |
   23andMe is the personal genetics company building the largest people-powered platform for health, ancestry and drug discovery. We hope to empower people through access and understanding of their genetic data. Knowing your genetic health information will help you make better decisions.  23andMe is the only company in the world built to power global genetic research and translate the information into novel discoveries and therapeutics -- all with the power of consumer participation.
+hiring: false
 ---

--- a/_sponsors/2019-08-11-Heroku.md
+++ b/_sponsors/2019-08-11-Heroku.md
@@ -10,4 +10,5 @@ url_target: "https://www.heroku.com/"
 url_friendly: "www.heroku.com"
 description: |
   Heroku, a Salesforce company and industry pioneer in platform as a service (PaaS), enables developers to build and run applications entirely in the cloud, without the need to purchase or maintain any servers or software. Over 7 million apps, including ones from Product Hunt, Casper and Citrix run on Heroku. With support for the most popular languages such as Python, Ruby and Node.js, high-scale data services including Postgres, Redis and Kafka, and an add-ons ecosystem featuring over 150 cloud application services, Heroku provides companies from startups to Fortune 500 enterprises with a faster and more effective way to create, deploy and manage beautiful apps in the cloud.
+hiring: false
 ---

--- a/_sponsors/2019-08-11-microsoftcda.md
+++ b/_sponsors/2019-08-11-microsoftcda.md
@@ -14,4 +14,5 @@ description: |
   maniacal about making the world amazing for developers of all
   backgrounds. Connect with us, write code with us, and let's meet
   up and talk cloud and all things developer!
+hiring: false
 ---

--- a/_sponsors/2019-08-11-pathai.md
+++ b/_sponsors/2019-08-11-pathai.md
@@ -10,4 +10,5 @@ url_target: "https://www.pathai.com"
 url_friendly: "www.pathai.com"
 description: |
   PathAI builds AI-powered tools for pathology research to help bring us all closer to the promise of precision medicine. Our Python-based platform promises substantial improvements to the accuracy of diagnosis, and the effectiveness of treatment, of diseases like cancer, leveraging modern approaches in machine and deep learning. Based in Boston, our cross-disciplinary teams of engineers, designers, scientists, and and staff work to ship software we're proud of that can achieve results that would change the face of disease.
+hiring: false
 ---

--- a/_sponsors/2019-08-11-rover.md
+++ b/_sponsors/2019-08-11-rover.md
@@ -10,4 +10,5 @@ url_target: "https://www.rover.com/"
 url_friendly: "rover.com"
 description: |
   Rover.com is the nation’s largest online marketplace of 5-star pet sitters and dog walkers. Through Rover’s straight-forward website and app, anyone can easily find, message, and book a pet care provider who’ll treat their dog like family.
+hiring: false
 ---

--- a/_sponsors/2019-08-19-octobot.md
+++ b/_sponsors/2019-08-19-octobot.md
@@ -10,4 +10,5 @@ url_target: "https://www.octobot.io/"
 url_friendly: "octobot.io"
 description: |
   Octobot is a digital innovation agency.  Our passion is to design, develop, and deploy custom software solutions to transform ideas into products people love.  Our team of designers and engineers have worked on a variety of projects from startups and leading companies to governments and non-profit organizations. We would love to hear your ideas!
+hiring: false
 ---

--- a/_sponsors/2019-08-20-tidelift.md
+++ b/_sponsors/2019-08-20-tidelift.md
@@ -12,4 +12,5 @@ description: |
   Tidelift makes open source work better—for everyone. Through the Tidelift Subscription and in direct partnership with maintainers, Tidelift is a single source for proactively managed open source components and professional assurances around those components.
   Tidelift makes it possible for open source projects to
   thrive, so we can all create even more incredible software, even faster.
+hiring: false
 ---

--- a/_sponsors/2019-09-15-ordermark.md
+++ b/_sponsors/2019-09-15-ordermark.md
@@ -9,5 +9,6 @@ logo_orientation: "landscape"
 url_target: "https://www.ordermark.com/"
 url_friendly: "www.ordermark.com"
 description: |
-  Ordermark supports restaurants in this rapidly evolving restaurant tech and online ordering space. Our products and services help restaurants adapt to changing consumer trends and technology, while also unlocking new markets and increasing revenue. 
+  Ordermark supports restaurants in this rapidly evolving restaurant tech and online ordering space. Our products and services help restaurants adapt to changing consumer trends and technology, while also unlocking new markets and increasing revenue.
+hiring: false
 ---


### PR DESCRIPTION
Closes # .

Changes proposed in this PR:

- Adds link to jobs board from `Sponsors` page 
- Adds link to jobs board in nav under `About` 
- Adds link to jobs board on `FAQ` page 
- Updates `FAQ` page to link to schedule, reflect closed sponsorships, link to childcare info, link to lactation room info 
- Adds `hiring` element to all sponsor markown pages 
- Adds layout to `Sponsors` page to show `[NAME] is hiring!]` button if `hiring` is `true`, which links to the jobs board 

<img width="1316" alt="Screen Shot 2019-09-16 at 12 10 34 PM" src="https://user-images.githubusercontent.com/2286304/64986019-0bad6200-d87b-11e9-984d-5b8acec2b5f1.png">
<img width="386" alt="Screen Shot 2019-09-16 at 12 10 13 PM" src="https://user-images.githubusercontent.com/2286304/64986020-0bad6200-d87b-11e9-9a40-79c2446a7dc2.png">
<img width="1525" alt="Screen Shot 2019-09-16 at 12 09 34 PM" src="https://user-images.githubusercontent.com/2286304/64986021-0bad6200-d87b-11e9-9dde-8c673c1e446c.png">
<img width="1617" alt="Screen Shot 2019-09-16 at 12 01 34 PM" src="https://user-images.githubusercontent.com/2286304/64986022-0bad6200-d87b-11e9-8f2f-60d93ffb9d12.png">

