### PR TITLE
Update time for closing comments

### DIFF
--- a/_schedule/talks/2019-09-25-17-50-dsf-update.md
+++ b/_schedule/talks/2019-09-25-17-50-dsf-update.md
@@ -5,12 +5,13 @@ permalink:
 accepted: true
 sitemap: false
 
-title: Closing Comments
-presenters:
+title: Django Software Foundation Update
+presenters: Frank Wiles
 difficulty:
 
 date: 2019-09-25 17:50:00 -0500
 room: Salon A-E
+end_date: 2019-09-25 18:00:00 -0500
 schedule-layout: full
 talk_slot: full
 ---

--- a/_schedule/talks/2019-09-25-18-00-closing-comments
+++ b/_schedule/talks/2019-09-25-18-00-closing-comments
@@ -1,0 +1,17 @@
+---
+layout: session-details
+category: talk
+permalink:
+accepted: true
+sitemap: false
+
+title: Closing Comments
+presenters:
+difficulty:
+
+date: 2019-09-25 18:00:00 -0500
+room: Salon A-E
+schedule-layout: full
+talk_slot: full
+---
+Salon A-E


### PR DESCRIPTION
Closes # .

Changes proposed in this PR:

- update closing comments to 6:00pm on wednesday to allow time for Frank to talk about DSF
- Schedule Frank to talk Wednesday from 5:50 - 6:00pm about DSF stuff
