### PR TITLE
Add links to lightning talk registration

### DIFF
--- a/_schedule/talks/2019-09-24-12-50-t0-lightning-talks.md
+++ b/_schedule/talks/2019-09-24-12-50-t0-lightning-talks.md
@@ -16,4 +16,4 @@ track: t0
 
 Salon A-E
 
-Tuesday sign ups go live Monday at 2:20pm and close Tuesday at 9am (please eat breakfast!) with speaker notifications by 11am Tuesday.
+Tuesday sign ups go live Monday at 2:20pm and close Tuesday at 9am (please eat breakfast!) with speaker notifications by 11am Tuesday. Registration link: http://bit.ly/dcus2019lt

--- a/_schedule/talks/2019-09-24-12-50-t0-lightning-talks.md
+++ b/_schedule/talks/2019-09-24-12-50-t0-lightning-talks.md
@@ -16,4 +16,4 @@ track: t0
 
 Salon A-E
 
-Tuesday sign ups go live Monday at 2:20pm and close Tuesday at 9am (please eat breakfast!) with speaker notifications by 11am Tuesday. Registration link: http://bit.ly/dcus2019lt
+Tuesday sign ups go live Monday at 2:20pm and close Tuesday at 9am (please eat breakfast!) with speaker notifications by 11am Tuesday. [Register here!](http://bit.ly/dcus2019lt) 

--- a/_schedule/talks/2019-09-25-12-50-t0-lightning-talks.md
+++ b/_schedule/talks/2019-09-25-12-50-t0-lightning-talks.md
@@ -16,4 +16,4 @@ track: t0
 
 Salon A-E
 
-Wednesday sign ups go live Tuesday at 2:20pm and close Wednesday at 9am (please eat breakfast!) with speaker notifications by 11am Wednesday. Registration link: http://bit.ly/dcus2019lt
+Wednesday sign ups go live Tuesday at 2:20pm and close Wednesday at 9am (please eat breakfast!) with speaker notifications by 11am Wednesday. [Register here!](http://bit.ly/dcus2019lt)

--- a/_schedule/talks/2019-09-25-12-50-t0-lightning-talks.md
+++ b/_schedule/talks/2019-09-25-12-50-t0-lightning-talks.md
@@ -16,4 +16,4 @@ track: t0
 
 Salon A-E
 
-Wednesday sign ups go live Tuesday at 2:20pm and close Wednesday at 9am (please eat breakfast!) with speaker notifications by 11am Wednesday.
+Wednesday sign ups go live Tuesday at 2:20pm and close Wednesday at 9am (please eat breakfast!) with speaker notifications by 11am Wednesday. Registration link: http://bit.ly/dcus2019lt


### PR DESCRIPTION
Changes proposed in this PR:

- Adds links to lightning talk registration for 9/24 & 9/25
