### PR TITLE
Fix slides_url on speaking status page

### DIFF
--- a/_pages/speaking-status.md
+++ b/_pages/speaking-status.md
@@ -32,7 +32,7 @@ description: Our Speaking Status for YouTube catching missing links
   <td>{% if presenter.photo_url != blank %}✅{% else %}❌{% endif %}</td>
   <td>{% if post.video_url != blank %}✅{% else %}❌{% endif %}</td>
   <td>{% if presenter.github != blank %}✅{% else %}❌{% endif %}</td>
-  <td>{% if presenter.slides_url != blank %}✅{% else %}❌{% endif %}</td>
+  <td>{% if post.slides_url != blank %}✅{% else %}❌{% endif %}</td>
   <td>{% if presenter.twitter != blank %}✅{% else %}❌{% endif %}</td>
   <td>{% if presenter.website != blank %}✅{% else %}❌{% endif %}</td>
 </tr>


### PR DESCRIPTION
This page currently checks `presenter.slides_url` rather than `post.slides_url` and always evaluates to false. With this change, the data renders correctly.

Relates to #214. Verifying completeness of data should be easier with this change.

Changes proposed in this PR:

- Fix a typo.
