### PR TITLE
ℹ Add GitHub accounts for all Monday morning speakers

### DIFF
--- a/_presenters/kojo-idrissa.md
+++ b/_presenters/kojo-idrissa.md
@@ -1,6 +1,6 @@
 ---
 company: Decisio Health
-github: ''
+github: kojoidrissa
 layout: speaker-template
 name: Kojo Idrissa
 permalink: /presenters/kojo-idrissa/

--- a/_presenters/matt-mitchell.md
+++ b/_presenters/matt-mitchell.md
@@ -1,6 +1,6 @@
 ---
 company: Tactical Tech
-github: ''
+github: geminiimatt
 layout: speaker-template
 name: Matt Mitchell
 permalink: /presenters/matt-mitchell/

--- a/_presenters/melanie-crutchfield.md
+++ b/_presenters/melanie-crutchfield.md
@@ -1,6 +1,6 @@
 ---
 company: FiveUp
-github: ''
+github: HelloMelanieC
 layout: speaker-template
 name: Melanie Crutchfield
 permalink: /presenters/melanie-crutchfield/

--- a/_presenters/ryan-sullivan.md
+++ b/_presenters/ryan-sullivan.md
@@ -1,6 +1,6 @@
 ---
 company: Wharton Research Data Services (WRDS)
-github: ''
+github: rgs258
 layout: speaker-template
 name: Ryan Sullivan
 permalink: /presenters/ryan-sullivan/

--- a/_presenters/vanessa-barreiros.md
+++ b/_presenters/vanessa-barreiros.md
@@ -1,6 +1,6 @@
 ---
 company: Vinta Software
-github: ''
+github: vanessa
 layout: speaker-template
 name: Vanessa Barreiros
 permalink: /presenters/vanessa-barreiros/


### PR DESCRIPTION
Changes proposed in this PR:

- Add GitHub accounts for all Monday morning speakers who were missing GH links (everyone before lunch Monday)

Addresses #214 